### PR TITLE
Don't even use ".PsychEngine" Jordan for SUtil

### DIFF
--- a/source/SUtil.hx
+++ b/source/SUtil.hx
@@ -36,7 +36,7 @@ class SUtil
 		if (aDir != null && aDir.length > 0)
 			return aDir;
 		else
-			return aDir = Tools.getExternalStorageDirectory() + '/.PsychEngine/'; // i wanna do this to have the ability to use same mods from other ports without making storage full
+			return aDir = Tools.getExternalStorageDirectory() + '/.JSEngine/'; // i wanna do this to have the ability to use same mods from other ports without making storage full
 		#else
 		return '';
 		#end


### PR DESCRIPTION
That's why is making an to detect assets from ".PsychEngine" because you don't have the correct folder name @JordanSantiagoYT